### PR TITLE
Adding golang examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ Use a checkmark ✓ if the issues are just ignored and the valid cookies are mad
 |---|:---:|:---:|:---:|---|
 | [bottlepy](/bottlepy) | python |✓|✗| |
 | [Flask](/flask) | python |✓|✗| Does not discard, but the bad and good cookie together: `{'SID': '31d4d96e407aad42', 'muffin ; lang': 'en-US'}`|
+| [pure go](/pure_go) | golang |✓|✓| Does not discard, assumes K/V pairs and adds an empty value to the invalid cookie value: `[SID=31d4d96e407aad42 lang=en-US][SID=31d4d96e407aad42 muffin= lang=en-US]`|
 | example for copy/paste |✓✗|✓✗|✓✗| |
 

--- a/gorilla_go/main.go
+++ b/gorilla_go/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func cookies(w http.ResponseWriter, r *http.Request) {
@@ -13,6 +15,7 @@ func cookies(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	http.HandleFunc("/", cookies)
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/", cookies).Methods("GET")
+	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/pure_go/main.go
+++ b/pure_go/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+import "net/http"
+
+func cookies(w http.ResponseWriter, r *http.Request) {
+	fmt.Println(r.Cookies())
+}
+
+func main() {
+	http.HandleFunc("/", cookies)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
I've added a pure golang example. Golang handles the invalid cookies.

```curl -b 'SID=31d4d96e407aad42; muffin ; lang=en-US;' localhost:8080```
```[SID=31d4d96e407aad42 muffin= lang=en-US]```

```curl -b 'SID=31d4d96e407aad42; lang=en-US;' localhost:8080```
```[SID=31d4d96e407aad42 lang=en-US]```